### PR TITLE
DEV: Deprecate theme, add admin notice (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# DEPRECATED: This theme is now included as a core Discourse theme in https://github.com/discourse/discourse,
+# if you have this theme installed, please remove it.
+
 Horizon is a simple, beautiful theme that improves the out-of-the-box experience for Discourse sites.
 
 https://meta.discourse.org/t/horizon-theme/360486

--- a/about.json
+++ b/about.json
@@ -1,5 +1,5 @@
 {
-  "name": "Horizon",
+  "name": "Horizon (beta)",
   "authors": "Design Team",
   "about_url": "https://meta.discourse.org/t/horizon-theme/360486",
   "license_url": "https://github.com/discourse/horizon/blob/main/LICENSE",

--- a/javascripts/discourse/api-initializers/horizon.gjs
+++ b/javascripts/discourse/api-initializers/horizon.gjs
@@ -1,8 +1,26 @@
+import { addGlobalNotice } from "discourse/components/global-notice";
 import { apiInitializer } from "discourse/lib/api";
+import getURL from "discourse/lib/get-url";
+import { currentThemeId } from "discourse/lib/theme-selector";
 import ExperimentalScreen from "../components/experimental-screen";
 import UserColorPaletteSelector from "../components/user-color-palette-selector";
 
 export default apiInitializer("1.8.0", (api) => {
+  if (api.getCurrentUser()?.admin) {
+    const themeId = currentThemeId();
+    const themeURL = getURL(`/admin/customize/themes/${themeId}`);
+    const horizonThemeUrl = getURL(`/admin/customize/themes/-2`);
+    addGlobalNotice(
+      `<b>Admin notice:</b> you are using the <em>Horizon (beta)</em> theme. This theme is now installed automatically in Discourse core. You should <a href="${themeURL}">uninstall this theme</a>, and reconfigure the <a href="${horizonThemeUrl}">preinstalled Horizon theme</a>.`,
+      "loading-slider-theme",
+      {
+        dismissable: true,
+        level: "warn",
+        dismissDuration: moment.duration("1", "hour"),
+      }
+    );
+  }
+
   api.renderInOutlet("above-main-container", ExperimentalScreen);
   api.renderInOutlet("sidebar-footer-actions", UserColorPaletteSelector);
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,6 +1,6 @@
 en:
   theme_metadata:
-    description: "A simple, beautiful theme that improves the out of the box experience for Discourse sites."
+    description: "(DEPRECATED: Use the Horizon theme that is now preinstalled on your Discourse site). A simple, beautiful theme that improves the out of the box experience for Discourse sites."
   topic_pinned: "Pinned"
   topic_hot: "Hot"
   user_replied: "replied"


### PR DESCRIPTION
The Horizon theme will soon be installed by default in Discourse, and all development will be done there. This commit shows a warning for admins telling them to switch to the new theme.